### PR TITLE
Add `token` parameter for RPCManager dispatch

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -45,7 +45,7 @@ async def test_aclose():
 
     async with anyio.create_task_group() as task_group:
         task_group.start_soon(
-            rpc.dispatch_request, request.id, request.method, request.args, request.kwargs, dummy_sender
+            rpc.dispatch_request, 0, request.id, request.method, request.args, request.kwargs, dummy_sender
         )
         await started.wait()
         await rpc.aclose()


### PR DESCRIPTION
There may be multiple server instances (one for each client) interacting with
one RPCManager.  With only the `request_id` to differentiate in-flight
requests, we will run in to collisions.  This change adds a `token` based
on the identity of `RPCServer` to avoid collisions.