### PR TITLE
improve RemoteError to include traceback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: ["--markdown-linebreak-ext=md"]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/src/rpcx/server.py
+++ b/src/rpcx/server.py
@@ -2,6 +2,7 @@ import inspect
 import logging
 import math
 import sys
+import traceback
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, Dict, Optional, Tuple, get_type_hints
 
@@ -184,12 +185,12 @@ class RPCServer:
             if sent_stream_chunk:
                 await self.send_stream_end(request.id)
             await self.send_response(request.id, ResponseStatus.OK, result)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError):
             LOG.exception("Invalid request")
-            await self.send_response(request.id, ResponseStatus.INVALID, repr(exc))
+            await self.send_response(request.id, ResponseStatus.INVALID, traceback.format_exc())
         except Exception as exc:
             LOG.warning("rpc error: %s", request, exc_info=exc)
-            await self.send_response(request.id, ResponseStatus.ERROR, repr(exc))
+            await self.send_response(request.id, ResponseStatus.ERROR, traceback.format_exc())
 
     async def handle_event(self, msg: Message) -> None:
         """

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -35,7 +35,7 @@ async def test_simple_error(test_stack):
     manager.register("simple_error", simple_error)
 
     async with test_stack(manager) as stack:
-        with pytest.raises(RemoteError):
+        with pytest.raises(RemoteError, match="Traceback \(most recent call last\):\\n"):
             await stack.client.request("simple_error")
 
 


### PR DESCRIPTION
Give remote error a more detailed trace back to allow more effective debugging.