### PR TITLE
lint: migrate to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: ["commit", "push"]
+default_stages: ["pre-commit", "pre-push"]
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -17,24 +17,15 @@ repos:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
 
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.11.4
     hooks:
-      - id: isort
-        name: isort (python)
-      - id: isort
-        name: isort (cython)
-        types: ["cython"]
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black
-
-  - repo: https://github.com/flakeheaven/flakeheaven
-    rev: 3.3.0
-    hooks:
-      - id: flakeheaven
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
 
   # Run mypy locally to reuse poetry dev environment
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,51 +45,16 @@ show_column_numbers = true
 show_error_codes = true
 files = "src/**/*.py"
 
-[tool.black]
+[tool.ruff]
 line-length = 120
-target-version = ['py39']
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
 
-[tool.isort]
-profile = "black"
-line_length = 120
+[tool.ruff.lint]
+select = ["A", "B", "C4", "ERA", "F", "I", "PT", "S"]
+ignore = ["A002", "B9", "PT011", "PT012"]
 
-[tool.flakeheaven]
-format = "colored"
-show_source = true
-max_line_length = 120
-
-[tool.flakeheaven.plugins]
-# Ignore redefinition of variable name in new scope
-pyflakes = ["+*", "-F823"]
-flake8-bandit = ["+*"]
-flake8-bugbear = ["+*"]
-flake8-builtins = ["+*"]
-flake8-comprehensions = ["+*"]
-flake8-darglint = ["+*"]
-flake8-docstrings = ["+*"]
-flake8-eradicate = ["+*"]
-flake8-mutable = ["+*"]
-flake8-pytest-style = ["+*"]
-flake8-spellcheck = ["+*"]
-
-[tool.flakeheaven.exceptions."**/__init__.py"]
-# Ignore unused imports in __init__.py files
-pyflakes = ["-F401"]
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/**.py" = ["S101"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Not all of the flake8 plugins had ruff equivalents and some of the checks that are supported fail when enabled via ruff.

For now, these are guarded by excludes until they can be fixed properly.

closes #182 