### PR TITLE
ci: add python 3.13 and 3.14 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  POETRY_VERSION: 1.6.1
+  POETRY_VERSION: 1.8.5
 
 jobs:
   test:


### PR DESCRIPTION
Closes #225  #226 

Start testing on newer CPython versions and emit warnings as part of the test suite to provide an indication of potential issues.

Bump poetry to 1.8.5 to squelch some warnings during dependency installs in CI